### PR TITLE
Passing actual bower config object to download function.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ module.exports = function (bower) {
 
             var downloadPath = tmp.dirSync();
 
-            return download(downloadUrl, downloadPath.name, this.config).then(function (archivePatch) {
+            return download(downloadUrl, downloadPath.name, bower.config).then(function (archivePatch) {
                 var extractPath = tmp.dirSync();
 
                 return extract(archivePatch, extractPath.name).then(function () {


### PR DESCRIPTION
Using non-standard bower settings (e.g. SSL & proxy) was working fine for fetching components but was failing during download. This fix used the actual bower settings object and passes it to the download function.
