### PR TITLE
Use _ca_ configurations from bowerrc

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -40,6 +40,7 @@ function download(requestUrl, downloadPath, config) {
 
     var _request = request.defaults({
         proxy: parsedUrl.protocol === 'https:' ? config.httpsProxy : config.proxy,
+        ca: config.ca.search[0],
         strictSSL: config.strictSsl,
         timeout: config.timeout
     })

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,6 +11,7 @@ function requestWrapper(requestUrl, config) {
 
     var _request = request.defaults({
         proxy: protocol === 'https:' ? config.httpsProxy : config.proxy,
+        ca: config.ca.search[0],
         strictSSL: config.strictSsl,
         timeout: config.timeout
     })


### PR DESCRIPTION
This fixes #11 

Commit c642748 made the assumption that the Artifactory URL must be
the first _search_ URL.

In line with the above, this commit makes the assumption that the first
_search_ CA is intended for Artifactory.

bower registery-client's search.js [0] currently associates the search URL
index with the search CA index.

[0] https://github.com/bower/registry-client/blob/master/lib/search.js#L106
