### PR TITLE
Let Request handle proxy based on env variables

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -39,7 +39,6 @@ function download(requestUrl, downloadPath, config) {
     }, config.retry || {});
 
     var _request = request.defaults({
-        proxy: parsedUrl.protocol === 'https:' ? config.httpsProxy : config.proxy,
         ca: config.ca.search[0],
         strictSSL: config.strictSsl,
         timeout: config.timeout

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,6 @@ function requestWrapper(requestUrl, config) {
     var protocol = url.parse(requestUrl).protocol;
 
     var _request = request.defaults({
-        proxy: protocol === 'https:' ? config.httpsProxy : config.proxy,
         ca: config.ca.search[0],
         strictSSL: config.strictSsl,
         timeout: config.timeout


### PR DESCRIPTION
Currently the `bower-art-resolver` is failing when it runs in a server behind a proxy and needs to resolve any dependency that the source is set to `NO_PROXY` environment variable.
As per investigation made by @monzonj in #9, removing the proxy entry from the request call let the request plugin to handle the environment variables to evaluate `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.

This change is a workaround to fix #9.
### Scenario:

We want to use the `bower-art-resolver` to resolve some packages dependencies from our internal Artifactory registry. The server we are running is behind a HTTP proxy and our internal Artifactory shouldn't be routed via proxy so its address is set in the `NO_PROXY` environment variable.
### Expected Result:

During the `bower install` command it is expected to have the `NO_PROXY` environment variable evaluated and the requests to the custom registry should bypass the proxy.
### Actual Result:

During the `bower install` command the `NO_PROXY` environment variable is not evaluated and every request is going though the proxy causing the following error when trying to reach the internal artifactory:

```
ECONNRESET Request to https://internal-artifactory/artifactory/api/bower/bower-virtual/refs/facebook/react-bower failed: tunneling socket could not be established, cause=Parse Error
```
